### PR TITLE
separator between credentials and host must be `@`, not `/`

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -30,7 +30,7 @@ func init() {
 func (c *Connection) Connect() error {
 	sqlconnstring := toolkit.Sprintf("%s/%s", c.Host, c.Database)
 	if c.User != "" {
-		sqlconnstring = toolkit.Sprintf("%s:%s/%s", c.User, c.Password, sqlconnstring)
+		sqlconnstring = toolkit.Sprintf("%s:%s@%s", c.User, c.Password, sqlconnstring)
 	}
 	sqlconnstring = "postgres://" + sqlconnstring
 	configs := strings.Join(func() []string {


### PR DESCRIPTION
Currently `Connect()` function will generate below connection string, and it's invalid one.

```bash
postgres://username:password/localhost/dbname
```

Separator between credentials and host must be `@`, not `/`. So the current one would be:

```bash
postgres://username:password@localhost/dbname
```

This pr will fix the particular issue
